### PR TITLE
Fixes a Spriting Issue in Mobvore

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -57,18 +57,18 @@
 	new_fullness = round(new_fullness, 1) // Because intervals of 0.25 are going to make sprite artists cry.
 	vore_fullness = min(vore_capacity, new_fullness)
 
-/mob/living/simple_mob/proc/update_vore_icon()
-	if(!vore_active)
-		return 0
-	update_fullness()
-	if(!vore_fullness)
-		return 0
-	else if((stat == CONSCIOUS) && (!icon_rest || !resting || !incapacitated(INCAPACITATION_DISABLED)) && (vore_icons & SA_ICON_LIVING))
-		return "[icon_living]-[vore_fullness]"
-	else if(stat >= DEAD && (vore_icons & SA_ICON_DEAD))
-		return "[icon_dead]-[vore_fullness]"
-	else if(((stat == UNCONSCIOUS) || resting || incapacitated(INCAPACITATION_DISABLED) ) && icon_rest && (vore_icons & SA_ICON_REST))
-		return "[icon_rest]-[vore_fullness]"
+/mob/living/simple_mob/update_icon()
+	. = ..()
+	if(vore_active)
+		update_fullness()
+		if(!vore_fullness)
+			return 0
+		else if((stat == CONSCIOUS) && (!icon_rest || !resting || !incapacitated(INCAPACITATION_DISABLED)) && (vore_icons & SA_ICON_LIVING))
+			icon_state = "[icon_living]-[vore_fullness]"
+		else if(stat >= DEAD && (vore_icons & SA_ICON_DEAD))
+			icon_state = "[icon_dead]-[vore_fullness]"
+		else if(((stat == UNCONSCIOUS) || resting || incapacitated(INCAPACITATION_DISABLED) ) && icon_rest && (vore_icons & SA_ICON_REST))
+			icon_state = "[icon_rest]-[vore_fullness]"
 
 /mob/living/simple_mob/proc/will_eat(var/mob/living/M)
 	if(client) //You do this yourself, dick!


### PR DESCRIPTION
As the title says, this pr's designed to fix the current spriting issues with mobvore ever since the AI Refactor update. After trial and error, I've discovered that several key elements in the code were missing compared to the old one. So, I integrated some of the old elements into the new one to success.

Changes:

- Adds some minor elements from the old mobvore code into the new one to help it update the sprites properly.

- Removes update_vore_icon proc and reintegrates the original update_icon child proc. It's more of a rename rather than a straight-up removal as all it does is add a few elements from the old proc into the new one and no longer making it a separate proc. It could work as it's own separate proc, but it's better safe than sorry.

- Several coding edits for the living, resting, and dead icon codes to allow it to register the mobs' icon states.

By the end of the day, this should allow the mobs' sprites to update based on how full they are again.